### PR TITLE
Render github content. 

### DIFF
--- a/packages/continuum-web/next.config.js
+++ b/packages/continuum-web/next.config.js
@@ -9,6 +9,9 @@ const nextConfig = {
     config.experiments = { asyncWebAssembly: true, layers: true };
     return config;
   },
+  images: {
+    domains: ['github.com', 'avatars.githubusercontent.com'],
+  },
 };
 
 module.exports = nextConfig;

--- a/packages/continuum-web/src/components/Layout.tsx
+++ b/packages/continuum-web/src/components/Layout.tsx
@@ -6,6 +6,7 @@ import { Header } from './ui/Header';
 import { useRouter } from 'next/router';
 import { Notification } from './ui/Notification';
 import { useNotificationState } from 'contexts/NotificationContext';
+import { useContentUpdate } from 'contexts/ContentContext';
 
 export const Layout = ({
   children,
@@ -21,6 +22,7 @@ export const Layout = ({
   const notificationState = useNotificationState();
   const [{ data: connectData, error: connectError }, connect] = useConnect();
   const [{ data: accountData, error: accountError }, disconnect] = useAccount();
+  const setContent = useContentUpdate();
 
   useEffect(() => {
     if (accountError) {
@@ -74,6 +76,7 @@ export const Layout = ({
 
   const handleSignOut = async () => {
     disconnect();
+    setContent(undefined);
     await signOut({ callbackUrl: `${process.env.NEXT_PUBLIC_URL}` });
   };
 

--- a/packages/continuum-web/src/components/home/GithubContent.tsx
+++ b/packages/continuum-web/src/components/home/GithubContent.tsx
@@ -1,9 +1,9 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { GradientBtn } from 'components/ui/GradientBtn';
-import { Content } from 'types';
 import { DynamicColorBtn } from 'components/ui/DynamicColorBtn';
 import { shorten } from 'utils/commitment';
+import { State } from 'contexts/ContentContext';
 
 export enum Action {
   MINT,
@@ -20,7 +20,7 @@ const ActionButton = (props: ActionButtonProps) => {
   if (props.mintAddress) {
     return (
       <a href={`https://explorer.pops.one/tx/${props.mintAddress}`}>
-        <div className="flex-shrink self-center justify-center items-center p-3 underline hover:text-gray-200">
+        <div className="flex-shrink self-center justify-center items-center p-3 underline hover:text-gray-500">
           {shorten(props.mintAddress)}
         </div>
       </a>
@@ -50,7 +50,7 @@ const ActionButton = (props: ActionButtonProps) => {
 };
 
 interface GithubContentProps {
-  contents: Content[];
+  content: State;
   disable?: boolean;
   handleAction: ({
     commitmentId,
@@ -66,15 +66,36 @@ interface GithubContentProps {
 }
 export const GithubContent = (props: GithubContentProps) => {
   const { handleAction } = props;
+  const githubRaw = props.content?.github;
   return (
     <div className="m-6 border-2 border-gray-100 bg-gray-900 rounded-md px-4 py-2 text-left text-white flex flex-col justify-between">
       <div className="flex flex-row justify-between">
-        <div className="self-center flex flex-col">
+        <div className="self-center flex flex-col w-full">
           <p className="text-xl mb-1">Your Github Profile</p>
           <p className="text-sm">
             Github data will be only stored locally. It will be used for
             generating your proof.
           </p>
+          {githubRaw && (
+            <div className="my-3 gap-y-2 grid grid-cols-1 md:grid-cols-2 max-w-3xl">
+              <div className="col-span-2 py-2">
+                <Image
+                  src={githubRaw.avatar_url || '/GitHub-Mark-64px.png'}
+                  alt="github"
+                  className="rounded-full bg-slate-50"
+                  layout="intrinsic"
+                  width={128}
+                  height={128}
+                  draggable="false"
+                />
+              </div>
+              <p className="col-span-2">Name: {githubRaw.username}</p>
+              <p>Account Created: {githubRaw.created_at}</p>
+              <p>Followers: {githubRaw.followers}</p>
+              <p>Total stars: {githubRaw.receivedStars}</p>
+              <p>Public repos : {githubRaw.public_repos}</p>
+            </div>
+          )}
         </div>
         <Link
           passHref
@@ -96,38 +117,53 @@ export const GithubContent = (props: GithubContentProps) => {
           </GradientBtn>
         </Link>
       </div>
-      {props.contents && (
-        <ul role="list" className="py-4">
-          <li key="Header">
-            <div className="flex flex-row border-b-2 border-gray-700 mb-3">
-              <div className="flex-1">Data from Github</div>
-              <div className="flex-1 text-left">Data Revealed</div>
-            </div>
-          </li>
-          {props.contents.map(content => (
-            <li key={content.groupId}>
-              <div className="flex flex-row mb-2">
-                <div className="flex-1">{content.groupName}</div>
-                <div className="flex-1 text-left">
-                  {content.commitmentHash
-                    ? `Yes (commitment: ${shorten(content.commitmentHash)})`
-                    : 'No'}
-                </div>
-                <ActionButton
-                  disable={props.disable}
-                  commitmentHash={content.commitmentHash}
-                  mintAddress={content.mintAddress}
-                  handleAction={handleAction({
-                    commitmentId: content.commitmentId,
-                    groupId: content.groupId,
-                    groupName: content.groupName,
-                    groupNullifier: content.groupNullifier,
-                  })}
+      {props.content?.contents && (
+        <div className="pt-4">
+          <p className="text-xl mb-1">Data to reveal</p>
+          <ul role="list" className="py-4">
+            <li key="Header">
+              <div className="flex flex-row border-b-2 border-gray-700 mb-3">
+                <Image
+                  src="/GitHub-Mark-64px.png"
+                  alt="github"
+                  className="rounded-2xl absolute z-10"
+                  layout="intrinsic"
+                  width={32}
+                  height={32}
+                  draggable="false"
                 />
+                <div className="flex-1 text-lg">Criteria</div>
+                <div className="flex-1 text-lg text-center">Data Revealed</div>
+                <div className="text-center text-lg w-40">Action</div>
               </div>
             </li>
-          ))}
-        </ul>
+            {props.content.contents.map(content => (
+              <li key={content.groupId}>
+                <div className="flex flex-row mb-2 items-center">
+                  <div className="flex-1">{content.groupName}</div>
+                  <div className="flex-1 text-center">
+                    {content.commitmentHash
+                      ? `Yes (commitment: ${shorten(content.commitmentHash)})`
+                      : 'No'}
+                  </div>
+                  <div className="mx-2">
+                    <ActionButton
+                      disable={props.disable}
+                      commitmentHash={content.commitmentHash}
+                      mintAddress={content.mintAddress}
+                      handleAction={handleAction({
+                        commitmentId: content.commitmentId,
+                        groupId: content.groupId,
+                        groupName: content.groupName,
+                        groupNullifier: content.groupNullifier,
+                      })}
+                    />
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
       )}
     </div>
   );

--- a/packages/continuum-web/src/components/home/index.tsx
+++ b/packages/continuum-web/src/components/home/index.tsx
@@ -15,11 +15,10 @@ export const Home = () => {
   const session = useSession();
   const contentData = useContentState();
   const address = session.data?.address as string;
-  const [{ loading: verifyLoading }, verifygithub] = useVerify();
+  const [{ loading: verifyLoading }, verifygithub] = useVerify(address);
   const [{ data: signer }] = useSigner();
   const { addGroupStatus, generateIdentityCommitment, joinGroup } = useGroups();
   const { mintStatus, mint } = useMint();
-
   const code = router.query.code as string;
 
   useEffect(() => {
@@ -89,7 +88,7 @@ export const Home = () => {
     <div className="max-w-7xl mx-auto py-10 md:py-3 h-full bg-proved-500">
       {contentData.contents ? (
         <GithubContent
-          contents={contentData.contents}
+          content={contentData}
           handleAction={handleAction}
           disable={disable}
         />

--- a/packages/continuum-web/src/contexts/ContentContext.tsx
+++ b/packages/continuum-web/src/contexts/ContentContext.tsx
@@ -1,3 +1,4 @@
+import useLocalStorage from 'hooks/useLocalStorage';
 import {
   createContext,
   Dispatch,
@@ -6,9 +7,13 @@ import {
   useContext,
   useState,
 } from 'react';
-import { Content } from 'types';
+import { Content, GithubUser } from 'types';
 
-type State = { contents?: Content[] | undefined | null } | undefined;
+const env = process.env.NEXT_PUBLIC_ENV as string;
+
+export type State =
+  | { contents?: Content[] | undefined | null; github: GithubUser | null }
+  | undefined;
 
 const ContentStateContext = createContext<State>(undefined);
 const ContentUpdateContext = createContext<
@@ -16,11 +21,13 @@ const ContentUpdateContext = createContext<
 >(undefined);
 
 export const ContentProvider = ({ children }: { children: ReactNode }) => {
-  const [state, setState] = useState<State>({ contents: null });
-
+  const [storedValue, setStoredValue] = useLocalStorage<State>(
+    `Continuum:${env}`,
+    { contents: null, github: null },
+  );
   return (
-    <ContentStateContext.Provider value={state}>
-      <ContentUpdateContext.Provider value={setState}>
+    <ContentStateContext.Provider value={storedValue}>
+      <ContentUpdateContext.Provider value={setStoredValue}>
         {children}
       </ContentUpdateContext.Provider>
     </ContentStateContext.Provider>

--- a/packages/continuum-web/src/hooks/useLocalStorage.tsx
+++ b/packages/continuum-web/src/hooks/useLocalStorage.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+
+export default function useLocalStorage<T>(key: string, initialValue: T) {
+  // State to store our value
+  // Pass initial state function to useState so logic is only executed once
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    if (typeof window === 'undefined') {
+      return initialValue;
+    }
+    try {
+      // Get from local storage by key
+      const item = window.localStorage.getItem(key);
+      // Parse stored json or if none return initialValue
+      return item ? JSON.parse(item) : initialValue;
+    } catch (error) {
+      // If error also return initialValue
+      console.log(error);
+      return initialValue;
+    }
+  });
+  // Return a wrapped version of useState's setter function that ...
+  // ... persists the new value to localStorage.
+  const setValue = (value: T | ((val: T) => T)) => {
+    try {
+      // Allow value to be a function so we have same API as useState
+      const valueToStore =
+        value instanceof Function ? value(storedValue) : value;
+      // Save state
+      setStoredValue(valueToStore);
+      // Save to local storage
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(key, JSON.stringify(valueToStore));
+      }
+    } catch (error) {
+      // A more advanced implementation would handle the error case
+      console.log(error);
+    }
+  };
+  return [storedValue, setValue] as const;
+}

--- a/packages/continuum-web/src/hooks/useVerify.tsx
+++ b/packages/continuum-web/src/hooks/useVerify.tsx
@@ -1,7 +1,7 @@
 import { useContentUpdate } from 'contexts/ContentContext';
 import { useState } from 'react';
-
-export const useVerify = () => {
+const env = process.env.NEXT_PUBLIC_ENV as string;
+export const useVerify = (address: string) => {
   const [error, setError] = useState<Error | undefined>(undefined);
   const [loading, setLoading] = useState(false);
   const setContent = useContentUpdate();
@@ -28,7 +28,7 @@ export const useVerify = () => {
         })
       ).json();
 
-      setContent({ contents: result.contents });
+      setContent({ contents: result.contents, github: result.github });
     } catch (e) {
       console.log(e);
       setError(e as Error);

--- a/packages/continuum-web/src/types.ts
+++ b/packages/continuum-web/src/types.ts
@@ -26,6 +26,7 @@ export interface GithubParameters {
   proPlan?: boolean;
   public_repos: number;
   receivedStars?: number;
+  avatar_url: string;
 }
 
 export type GithubUser = User & GithubParameters;


### PR DESCRIPTION
## Overview(Purpose of this PR)

- Render github content
- Store github data and user data locally
- Closes #18

## Test Plan

- Make sure the content is rendered

## Visual(screenshots, animation, if any)
<img width="1235" alt="Screen Shot 2022-05-01 at 4 18 53 PM" src="https://user-images.githubusercontent.com/6277118/166150230-012c16de-a729-4336-9d92-2cf8ada63b4b.png">

