### PR TITLE
Support v16

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can find more details on https://speakerdeck.com/tomoima525/continuum-backgr
 
 # Preparation
 
-Call `yarn install` at the root of the project.
+Call `yarn install` at the root of the project. Note that this package requires node >= 16
 
 ### Github auth
 

--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ mainnet page: https://continuum.tomoima525.com/
   - Continuum generates MerkleProof from MerkleTree
   - On the client side, users generate a zkSNARK proof using the MerkleProof
   - Users submit the proof to the contract. Once verified, NFT will be issued.
-<p align="center">
-<img width="1000" alt="Screen Shot 2022-05-09 at 7 13 55 AM" src="https://user-images.githubusercontent.com/6277118/167317950-2158f5a9-7c1b-498c-94d9-c981f2877386.png">
-</p>
+  <p align="center">
+  <img width="1000" alt="Screen Shot 2022-05-09 at 7 13 55 AM" src="https://user-images.githubusercontent.com/6277118/167317950-2158f5a9-7c1b-498c-94d9-c981f2877386.png">
+  </p>
 
 You can find more details on https://speakerdeck.com/tomoima525/continuum-background-checker-with-zero-knowledge-proof or https://www.youtube.com/watch?v=bco4cvXuQUE
 
 # Preparation
 
-Call `yarn install --ignore-engines` at the root of the project. (ipfs contains node v16. It is used in Lambda but not required for the whole project)
+Call `yarn install` at the root of the project.
 
 ### Github auth
 

--- a/packages/cdk/functions/genMetadata/index.ts
+++ b/packages/cdk/functions/genMetadata/index.ts
@@ -76,7 +76,7 @@ async function storeNFT({
 export const handler = async function (
   event: APIGatewayProxyEvent,
 ): Promise<APIGatewayProxyResult> {
-  console.log('==== env', process.env.AWS_EXECUTION_ENV);
+  // console.log('==== env', process.env.AWS_EXECUTION_ENV);
   const requestBody = JSON.parse(event.body || '');
   const address = requestBody?.address as string;
   const groupId = requestBody?.groupId as string;

--- a/packages/cdk/functions/genMetadata/index.ts
+++ b/packages/cdk/functions/genMetadata/index.ts
@@ -3,6 +3,7 @@ import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { NFTStorage, File } from 'nft.storage';
 import screenshot from './screenshot';
 import { groupQuery } from '/opt/nodejs/dynamodb-utils';
+import { URLSearchParams } from 'url';
 
 const headers = {
   'Access-Control-Allow-Origin': '*',

--- a/packages/cdk/functions/genMetadata/package.json
+++ b/packages/cdk/functions/genMetadata/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",
-  "scripts": {
-    "build": "tsc --project ./tsconfig.json --skipLibCheck"
-  },
   "engines": {
     "npm": ">=7.0.0",
     "node": ">=16.0.0"

--- a/packages/cdk/functions/layers/chrome/nodejs/chrome-aws-lambda.ts
+++ b/packages/cdk/functions/layers/chrome/nodejs/chrome-aws-lambda.ts
@@ -1,5 +1,5 @@
 // work around to run in node16
 // https://github.com/alixaxel/chrome-aws-lambda/issues/268
-process.env.AWS_EXECUTION_ENV = 'AWS_Lambda_nodejs14.x';
-import chrome from 'chrome-aws-lambda';
+process.env.AWS_EXECUTION_ENV = 'AWS_Lambda_nodejs16.x';
+import chrome from '@sparticuz/chrome-aws-lambda';
 export default chrome;

--- a/packages/cdk/functions/layers/chrome/nodejs/package.json
+++ b/packages/cdk/functions/layers/chrome/nodejs/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "chrome-aws-lambda": "^10.1.0",
+    "@sparticuz/chrome-aws-lambda": "^14.1.0",
     "puppeteer-core": "10.1.0"
   }
 }

--- a/packages/cdk/functions/layers/chrome/nodejs/yarn.lock
+++ b/packages/cdk/functions/layers/chrome/nodejs/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@sparticuz/chrome-aws-lambda@^14.1.0":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@sparticuz/chrome-aws-lambda/-/chrome-aws-lambda-14.1.0.tgz#432de2dd6a8fd3d83025b35df51af40facf77fd1"
+  integrity sha512-Ef6MWjPyiHE94KOPtWP4Gd0KMh4W3MKBtni5gszgBeXQrB8QS3rEr8zZU21Axw9GmGyizTCbSZnYkPcgRB6lAQ==
+  dependencies:
+    lambdafs "^2.0.3"
+
 "@types/node@*":
   version "17.0.31"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.31.tgz#a5bb84ecfa27eec5e1c802c6bbf8139bdb163a5d"
@@ -65,13 +72,6 @@ chownr@^1.1.1:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
-
-chrome-aws-lambda@^10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/chrome-aws-lambda/-/chrome-aws-lambda-10.1.0.tgz#ac43b4cdfc1fbb2275c62effada560858099501e"
-  integrity sha512-NZQVf+J4kqG4sVhRm3WNmOfzY0OtTSm+S8rg77pwePa9RCYHzhnzRs8YvNI6L9tALIW6RpmefWiPURt3vURXcw==
-  dependencies:
-    lambdafs "^2.0.3"
 
 concat-map@0.0.1:
   version "0.0.1"

--- a/packages/cdk/lib/group-lambda-stack.ts
+++ b/packages/cdk/lib/group-lambda-stack.ts
@@ -152,6 +152,12 @@ export class GroupLambdaStack extends Construct {
         },
         timeout: Duration.minutes(1),
         memorySize: 1536,
+        bundling: {
+          externalModules: [
+            'aws-sdk', // Use the 'aws-sdk' available in the Lambda runtime
+            'chrome-aws-lambda', // Do not include this to prevent `/var/bin/chrome.br` does not exist error
+          ],
+        },
         layers: [props.dbUtilLayer, props.chromeLayer],
       },
     );

--- a/packages/cdk/lib/group-lambda-stack.ts
+++ b/packages/cdk/lib/group-lambda-stack.ts
@@ -155,7 +155,7 @@ export class GroupLambdaStack extends Construct {
         bundling: {
           externalModules: [
             'aws-sdk', // Use the 'aws-sdk' available in the Lambda runtime
-            'chrome-aws-lambda', // Do not include this to prevent `/var/bin/chrome.br` does not exist error
+            '@sparticuz/chrome-aws-lambda', // Do not include this to prevent `/var/bin/chrome.br` does not exist error
           ],
         },
         layers: [props.dbUtilLayer, props.chromeLayer],

--- a/packages/cdk/lib/group-lambda-stack.ts
+++ b/packages/cdk/lib/group-lambda-stack.ts
@@ -131,34 +131,30 @@ export class GroupLambdaStack extends Construct {
     );
     props.continuumTable.grantReadWriteData(this.createMerkleProofV2Lambda);
 
-    // Work around to use nft.storage which is supported node 16+
-    // https://fusebit.io/blog/run-every-nodejs-version-in-lambda
-    // https://github.com/fusebit/everynode
-    // https://github.com/aws/aws-lambda-base-images/issues/14
-    const customNodeLayer = lambda.LayerVersion.fromLayerVersionArn(
+    this.genMetadataLambda = new lambda_nodejs.NodejsFunction(
       this,
-      'customNode',
-      'arn:aws:lambda:us-west-2:072686360478:layer:node-16_14_2:1',
-    );
-
-    this.genMetadataLambda = new lambda.Function(this, 'genMetadata', {
-      runtime: new lambda.Runtime('nodejs16.x', lambda.RuntimeFamily.NODEJS),
-      handler: 'index.handler',
-      code: lambda.Code.fromAsset(
-        path.join(`${__dirname}/../`, 'functions', 'genMetadata'),
-      ),
-      environment: {
-        TableName: props.continuumTable.tableName,
-        SITE_URL:
-          deployEnv() === 'dev'
-            ? 'https://continuum-swart.vercel.app'
-            : 'https://continuum.tomoima525.com',
-        nftstorage_key_id: `continuum_nft_key_${deployEnv()}`,
+      'genMetadata',
+      {
+        runtime: lambda.Runtime.NODEJS_16_X,
+        handler: 'handler',
+        entry: path.join(
+          `${__dirname}/../`,
+          'functions',
+          'genMetadata/index.ts',
+        ),
+        environment: {
+          TableName: props.continuumTable.tableName,
+          SITE_URL:
+            deployEnv() === 'dev'
+              ? 'https://continuum-swart.vercel.app'
+              : 'https://continuum.tomoima525.com',
+          nftstorage_key_id: `continuum_nft_key_${deployEnv()}`,
+        },
+        timeout: Duration.minutes(1),
+        memorySize: 1536,
+        layers: [props.dbUtilLayer, props.chromeLayer],
       },
-      timeout: Duration.minutes(1),
-      memorySize: 1536,
-      layers: [props.dbUtilLayer, customNodeLayer, props.chromeLayer],
-    });
+    );
     props.continuumTable.grantReadWriteData(this.genMetadataLambda);
     this.genMetadataLambda.addToRolePolicy(props.secretManagerPolicy);
   }

--- a/packages/cdk/lib/layer-stack.ts
+++ b/packages/cdk/lib/layer-stack.ts
@@ -13,6 +13,7 @@ export class LambdaLayerSetup extends Construct {
       compatibleRuntimes: [
         lambda.Runtime.NODEJS_12_X,
         lambda.Runtime.NODEJS_14_X,
+        lambda.Runtime.NODEJS_16_X,
       ],
       code: lambda.Code.fromAsset('functions/layers/cdk-crypto'),
       description: 'crypto components',
@@ -22,7 +23,7 @@ export class LambdaLayerSetup extends Construct {
       compatibleRuntimes: [
         lambda.Runtime.NODEJS_12_X,
         lambda.Runtime.NODEJS_14_X,
-        new lambda.Runtime('nodejs16.x', lambda.RuntimeFamily.NODEJS),
+        lambda.Runtime.NODEJS_16_X,
       ],
       code: lambda.Code.fromAsset('functions/layers/dynamodb'),
       description: 'dynamodb utility components',
@@ -32,7 +33,7 @@ export class LambdaLayerSetup extends Construct {
       compatibleRuntimes: [
         lambda.Runtime.NODEJS_12_X,
         lambda.Runtime.NODEJS_14_X,
-        new lambda.Runtime('nodejs16.x', lambda.RuntimeFamily.NODEJS),
+        lambda.Runtime.NODEJS_16_X,
       ],
       code: lambda.Code.fromAsset('functions/layers/chrome'),
       description: 'chrome components',

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
-    "aws-cdk": "^2.22.0",
+    "aws-cdk": "^2.24.1",
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
     "ts-node": "^9.0.0",

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -22,7 +22,7 @@
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.22.0",
+    "aws-cdk-lib": "^2.24.1",
     "constructs": "^10.0.0",
     "source-map-support": "^0.5.16"
   }

--- a/packages/continuum-web/src/hooks/useMint.tsx
+++ b/packages/continuum-web/src/hooks/useMint.tsx
@@ -58,6 +58,7 @@ export default function useMint(): ReturnParameters {
           wasmFilePath: './semaphore.wasm',
           zkeyFilePath: './semaphore_final.zkey',
         };
+        console.log('=== tt', { groupId, identityCommitment });
         // Step 1 fetch leaves
         const result = await (
           await fetch(

--- a/yarn.lock
+++ b/yarn.lock
@@ -4046,10 +4046,10 @@ aws-cdk@^2.20.0:
   optionalDependencies:
     fsevents "2.3.2"
 
-aws-cdk@^2.22.0:
-  version "2.22.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-2.22.0.tgz#3d0a3158f228f398faed49d73372f8aa351034bf"
-  integrity sha512-oF3VCv/rtuLk8eLb6CBEWvEobabG8q05ersawGEy9CBhKbKNjfY1FDz6gc3ssksTwfcJqyJms2l/BQlLMBjugw==
+aws-cdk@^2.24.1:
+  version "2.24.1"
+  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-2.24.1.tgz#88c3ece3c01674fbed4e131f3391aa199b5e3871"
+  integrity sha512-fDcJW7tLbqsCvWB3eZY6glRrjRE45VqLT+JuKz3C2jIe6qXkwV8dBwYXElwY/tTCh/hDlpWtCNMRdhmrdE25GQ==
   optionalDependencies:
     fsevents "2.3.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4024,10 +4024,10 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-aws-cdk-lib@^2.22.0:
-  version "2.22.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.22.0.tgz#21b13764eff8c44cfe8ab03509a173ee8b661475"
-  integrity sha512-Orz+c746XGm1QBJKb3Wh6qH2rpmHdYMS5A4Wk91niYzrY4Q2kck/XLeQtEwOzscbW2Hqwc6vXTEpkldAI2pzGw==
+aws-cdk-lib@^2.24.1:
+  version "2.24.1"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.24.1.tgz#197d10216b384850c01205acc8e4818838964302"
+  integrity sha512-xGeEX+9wPGppSiIUdf/JTLMmqMikGhlSi7bjijl3lwncZtySkdjX0j+W2A1fuKp0S8Yd2axkwVkltIMxzNH/gw==
   dependencies:
     "@balena/dockerignore" "^1.0.2"
     case "1.6.3"
@@ -4036,7 +4036,7 @@ aws-cdk-lib@^2.22.0:
     jsonschema "^1.4.0"
     minimatch "^3.1.2"
     punycode "^2.1.1"
-    semver "^7.3.6"
+    semver "^7.3.7"
     yaml "1.10.2"
 
 aws-cdk@^2.20.0:
@@ -14287,7 +14287,7 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.2.1, semver@^7.3.4, semver@^7.3.6:
+semver@^7.2.1, semver@^7.3.4, semver@^7.3.7:
   version "7.3.7"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
   integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==


### PR DESCRIPTION
## Overview(Purpose of this PR)

- Finally lambda supporting v16 https://github.com/aws/aws-lambda-base-images/issues/14 
- Replacing workarounds for v14
  - Addressing libsso missing issue with v16 https://github.com/alixaxel/chrome-aws-lambda/pull/264
  - Addressing the issue with chrome.br missing https://github.com/alixaxel/chrome-aws-lambda/issues/270

## Test Plan

- Make sure build passes and deployed API works as expected

## Visual(screenshots, animation, if any)
Generated image
ipfs://bafybeihucbxpiau237tgess2njkfoeq7c4743txxxrbbudmsdhrjdxvhc4/0x98cEbab8451FDb86B9Cd1200D5aa1ED2b97aFc01_Group%238bf9cb2dcaa5d2882e3608f400b544c9
<img width="884" alt="Screen Shot 2022-05-19 at 1 45 10 PM" src="https://user-images.githubusercontent.com/6277118/169208181-9bbf8bc9-9871-44f8-a2fb-8db7da1d64f4.png">

